### PR TITLE
re: ensure runtime deps

### DIFF
--- a/packages/cutefetch.nix
+++ b/packages/cutefetch.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "cutefetch";
-  version = "0.2";
+  version = "0.3";
 
   src = fetchFromGitHub {
     owner = "cybardev";
@@ -16,23 +16,24 @@ stdenv.mkDerivation rec {
     hash = "sha256-DMp8tc1r5g3kHtboRp2xmx1o3Ze5UMqoYUHQwlT/gbI=";
   };
 
-  # specify runtime dependencies
-  buildInputs = with pkgs; [ networkmanager xorg.xprop xorg.xdpyinfo ];
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
   buildPhase = ''
     runHook preBuild
-    echo "${pkgs.networkmanager}/bin/nmcli" >> .deps
-    echo "${pkgs.xorg.xdpyinfo}/bin/xdpyinfo" >> .deps
-    echo "${pkgs.xorg.xprop}/bin/xprop" >> .deps
+    chmod +x cutefetch
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    cp .deps $out/
-    chmod +x cutefetch
     cp cutefetch $out/bin/
     runHook postInstall
+  '';
+
+  postInstall = with pkgs; ''
+    wrapProgram $out/bin/cutefetch \
+      --prefix PATH : ${lib.makeBinPath [ networkmanager xorg.xprop xorg.xdpyinfo ]}
   '';
 
   meta = {

--- a/packages/ytgo.nix
+++ b/packages/ytgo.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   buildGoModule,
   fetchFromGitHub,
 }:
@@ -15,11 +16,18 @@ buildGoModule rec {
     hash = "sha256-cAnZfXwk4zv9I8FDDe+xpR3TxlMgJjiLPT9h61iEqVY=";
   };
 
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
   vendorHash = "sha256-62bDFcunLygMpAY63C/b3g9L97XZ9HZbmz4RMecJwO4=";
 
   ldflags = [ "-s" "-w" ];
 
   doCheck = false;
+
+  postFixup = with pkgs; ''
+    wrapProgram $out/bin/ytgo \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg yt-dlp mpv ]}
+  '';
 
   meta = {
     description = "A Go program to find and watch YouTube videos from the terminal without requiring API keys";


### PR DESCRIPTION
Add runtime dependencies for `ytgo` and `cutefetch`.

**PS**: for cutefetch, only Linux runtime deps are checked, not macOS deps. This is because some macOS deps are preinstalled and exclusive to macOS.